### PR TITLE
update all services to use api root

### DIFF
--- a/src/services/ServiceAnswerService.js
+++ b/src/services/ServiceAnswerService.js
@@ -1,15 +1,13 @@
+import {API_ROOT} from '../api-config';
+
 export default class ServiceAnswerService {
     static instance = null;
     static getInstance() {
-        if(ServiceAnswerService.instance === null) {
-            ServiceAnswerService.instance = new ServiceAnswerService()
+        if (ServiceAnswerService.instance === null) {
+            ServiceAnswerService.instance = new ServiceAnswerService();
         }
-        return this.instance
+        return this.instance;
     }
-    findServiceAnswerById = id =>
-    fetch(`http://localhost:8080/api/service-answers/${id}`)
-    .then(response => response.json())
-    findAllServiceAnswers = () =>
-    fetch("http://localhost:8080/api/service-answers")
-    .then(response => response.json())
+    findServiceAnswerById = (id) => fetch(`${API_ROOT}/api/service-answers/${id}`).then((response) => response.json());
+    findAllServiceAnswers = () => fetch(`${API_ROOT}/api/service-answers`).then((response) => response.json());
 }

--- a/src/services/ServiceQuestionService.js
+++ b/src/services/ServiceQuestionService.js
@@ -3,15 +3,12 @@ import {API_ROOT} from '../api-config';
 export default class ServiceQuestionService {
     static instance = null;
     static getInstance() {
-        if(ServiceQuestionService.instance === null) {
-            ServiceQuestionService.instance = new ServiceQuestionService()
+        if (ServiceQuestionService.instance === null) {
+            ServiceQuestionService.instance = new ServiceQuestionService();
         }
-        return this.instance
+        return this.instance;
     }
-    findServiceQuestionById = id =>
-        fetch(`http://localhost:8080/api/service-questions/${id}`)
-            .then(response => response.json())
-    findAllServiceQuestions = () =>
-        fetch("http://localhost:8080/api/service-questions")
-            .then(response => response.json())
+    findServiceQuestionById = (id) =>
+        fetch(`${API_ROOT}/api/service-questions/${id}`).then((response) => response.json());
+    findAllServiceQuestions = () => fetch(`${API_ROOT}/api/service-questions`).then((response) => response.json());
 }

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,15 +1,13 @@
+import {API_ROOT} from '../api-config';
+
 export default class UserService {
     static instance = null;
     static getInstance() {
-        if(UserService.instance === null) {
-            UserService.instance = new UserService()
+        if (UserService.instance === null) {
+            UserService.instance = new UserService();
         }
-        return this.instance
+        return this.instance;
     }
-    findUserById = userId =>
-        fetch(`http://localhost:8080/api/users/${userId}`)
-            .then(response => response.json())
-    findAllUsers = () =>
-        fetch("http://localhost:8080/api/users")
-            .then(response => response.json())
+    findUserById = (userId) => fetch(`${API_ROOT}/api/users/${userId}`).then((response) => response.json());
+    findAllUsers = () => fetch(`${API_ROOT}/api/users`).then((response) => response.json());
 }


### PR DESCRIPTION
Prettier config made some style changes, but this just changes hard-coded `localhost:8080`s to use the `API_ROOT` const so this will work on Heroku.